### PR TITLE
fix link url of description

### DIFF
--- a/src/main/java/jp/jyane/grpc/annotations/checkers/ExperimentalApiChecker.java
+++ b/src/main/java/jp/jyane/grpc/annotations/checkers/ExperimentalApiChecker.java
@@ -18,19 +18,50 @@ package jp.jyane.grpc.annotations.checkers;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.Tree;
+import java.util.Map.Entry;
+import java.util.Optional;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
 
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "ExperimentalApi",
     summary = "@ExperimentalApi should not be used in application code",
     explanation = "@ExperimentalApi should not be used in application code",
-    severity = SeverityLevel.ERROR
+    severity = SeverityLevel.ERROR,
+    linkType = LinkType.CUSTOM,
+    link = "https://github.com/grpc/grpc-java"
 )
 public final class ExperimentalApiChecker extends AnnotationChecker {
 
   public ExperimentalApiChecker() {
     super("io.grpc", "io.grpc.ExperimentalApi");
+  }
+
+  private Optional<String> findLink(AnnotationMirror annotation) {
+    // Currently, @ExperimentalApi may have a link.
+    for (Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotation
+        .getElementValues().entrySet()) {
+      return Optional.of(entry.getValue().toString());
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  protected Description describe(Tree tree, AnnotationMirror annotation) {
+    String link = findLink(annotation).orElse(this.linkUrl());
+    return Description.builder(
+        tree,
+        this.canonicalName(),
+        link,
+        this.defaultSeverity(),
+        this.message())
+        .build();
   }
 }

--- a/src/main/java/jp/jyane/grpc/annotations/checkers/InternalChecker.java
+++ b/src/main/java/jp/jyane/grpc/annotations/checkers/InternalChecker.java
@@ -18,19 +18,30 @@ package jp.jyane.grpc.annotations.checkers;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.Tree;
+import javax.lang.model.element.AnnotationMirror;
 
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "Internal",
     summary = "@Internal should not be used in application code",
     explanation = "@Internal should not be used in application code",
-    severity = SeverityLevel.ERROR
+    severity = SeverityLevel.ERROR,
+    linkType = LinkType.CUSTOM,
+    link = "https://github.com/grpc/grpc-java"
 )
 public final class InternalChecker extends AnnotationChecker {
 
   public InternalChecker() {
     super("io.grpc", "io.grpc.Internal");
+  }
+
+  @Override
+  protected Description describe(Tree tree, AnnotationMirror annotation) {
+    return describeMatch(tree);
   }
 }

--- a/src/test/java/jp/jyane/grpc/annotations/checkers/ExperimentalApiCheckerTest.java
+++ b/src/test/java/jp/jyane/grpc/annotations/checkers/ExperimentalApiCheckerTest.java
@@ -65,8 +65,8 @@ public class ExperimentalApiCheckerTest {
         "@Internal",
         "@Retention(RetentionPolicy.SOURCE)",
         "@Target({",
-        "    ElementType.ANNOTATION_TYPE,",
-        "    ElementType.CONSTRUCTOR,",
+        "   ElementType.ANNOTATION_TYPE,",
+        "   ElementType.CONSTRUCTOR,",
         "   ElementType.FIELD,",
         "   ElementType.METHOD,",
         "   ElementType.PACKAGE,",
@@ -82,7 +82,7 @@ public class ExperimentalApiCheckerTest {
         "",
         "import io.grpc.ExperimentalApi;",
         "",
-        "@ExperimentalApi",
+        "@ExperimentalApi(\"https://example.com/issue\")",
         "public class AnnotatedClass {",
         "  public static final int MEMBER = 42;",
         "  public static int foo() { return 42; }",
@@ -190,7 +190,7 @@ public class ExperimentalApiCheckerTest {
   }
 
   @Test
-  public void positiveInstantiation() {
+  public void positiveInstantiationAndCaptureDescriptionLinkUrl() {
     compiler
         .addSourceLines("example/Test.java",
             "package example;",
@@ -200,7 +200,7 @@ public class ExperimentalApiCheckerTest {
             "",
             "public class Test {",
             "  public static void main(String[] args) {",
-            "    // BUG: Diagnostic contains: ",
+            "    // BUG: Diagnostic contains: https://example.com/issue",
             "    new AnnotatedClass();",
             "  }",
             "}")


### PR DESCRIPTION
`@ExperimentalApi` has a link of tracking.
Describing the link is useful for users.